### PR TITLE
Allow to push timesheets from current day, only if it's friday

### DIFF
--- a/wrappers/gtimelog_parser.py
+++ b/wrappers/gtimelog_parser.py
@@ -75,8 +75,11 @@ class GtimelogParser(object):
                 description
             ))
 
-        # Dangling attendance for today
-        if attendances and attendances[-1][1].date() == date.today():
-            attendances[-1] = (attendances[-1][0], None)
+        # Dangling attendance for today except friday
+        if attendances:
+            today = attendances[-1][1].date() == date.today()
+            friday = attendances[-1][1].weekday() == 4
+            if today and not friday:
+                attendances[-1] = (attendances[-1][0], None)
 
         return attendances, worklogs


### PR DESCRIPTION
Currently, if we try to run the script after the last task of the day, it does not push the end time of the last task, which is not a problem while the week isn't over.
On the next week, if we try to push the monday's timesheet, we get an error from Odoo complaining because we actually never signed out on the previous friday.
This PR allows to push the ending time of the last task only if we are friday.