### PR TITLE
Add dispatch feature: allow the duration repartition of a dispatch entry to every other non internal entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ You can add as many aliases as you want in the corresponding configuration file 
 Each alias is a key/value combination:
 > daily_alias = BSDEV-42
 
+### Internal issue references
+
+Blacklisted issue prefixes are used to avoid adding 'to dispatch' time on such entries
+
+You can add as many issue prefixes as you want in the corresponding configuration file section.
+> dispatch_blacklist_prefixes = BS-,BSRD-,ABCH-,ABFR-
+
 ### Passwords
 
 Upon script execution, you will be prompted for your Odoo password and Jira/Tempo tokens.
@@ -69,6 +76,10 @@ Where
 if `line_format` is `categorized`
 * (opt) "category" for instance a project name it won't be pushed
 
+if `description` contains a `++` sign, then this line will be
+considered as a dispatch line (i.e. duration will be equally added to all
+the non blacklisted entries)
+
 configuration option:
 
 
@@ -78,6 +89,8 @@ configuration option:
   > BSMP-42: Investigate issue
 * Log work to task aliased by `daily` with description "Daily Meeting"
   > daily: Daily Meeting
+* Log work to dispatch with description "Daily Meeting ++"
+  > daily: Daily Meeting ++
 
 ## Roadmap
 

--- a/gtimelogrc.example
+++ b/gtimelogrc.example
@@ -8,6 +8,7 @@ odoo_protocol = jsonrpc+ssl
 odoo_db = awesome_db_name
 odoo_user = my-user
 line_format = standard
+dispatch_blacklist_prefixes =
 
 [gtimelog_exporter:aliases]
 my-alias = ABC-42

--- a/wrappers/gtimelog_parser.py
+++ b/wrappers/gtimelog_parser.py
@@ -1,3 +1,5 @@
+import pprint
+
 try:
     from gtimelog.settings import Settings
     from gtimelog.timelog import TimeLog
@@ -18,12 +20,21 @@ class GtimelogParser(object):
                                self.settings.virtual_midnight)
         self.aliases = config.get('aliases', {})
         self.line_format = config.get('line_format', '')
+        self.dispatch_blacklist_prefixes = self.parse_dispatch_blacklist_prefixes(config)
         if self.line_format == 'categorized':
             self.line_format_str = "category: task description | comment"
             self.delimiter = " "
         else:
             self.line_format_str = "task: description | comment"
             self.delimiter = ":"
+
+    def parse_dispatch_blacklist_prefixes(self, config):
+        prefixes = config.get('dispatch_blacklist_prefixes', "").split(",")
+        # Cleanup in case of spaces
+        return [
+            prefix.strip() for prefix in prefixes
+            if prefix.strip()
+        ]
 
     def skip_entry(self, entry):
         if '**' in entry:
@@ -32,11 +43,109 @@ class GtimelogParser(object):
             return True
         return False
 
+    def is_dispatch_entry(self, entry):
+        """Returns whether or not this entry is a dispatch"""
+        return '++' in entry
+
+    def is_dispatch_entry_blacklisted(self, entry):
+        """Returns whether or not this entry will not be considered during
+        dispatch"""
+        if not self.dispatch_blacklist_prefixes:
+            return False
+        issue, description = self.get_issue_description(entry)
+        return any([
+            issue.startswith(ref)
+            for ref in self.dispatch_blacklist_prefixes
+        ])
+
+    def get_entries_to_dispatch(self, window):
+        """Returns non internal nor dispatchable nor skippable entries"""
+        return [
+            entry
+            for start, stop, duration, tags, entry in window.all_entries()
+            if not (
+                self.skip_entry(entry)
+                or self.is_dispatch_entry(entry)
+                or self.is_dispatch_entry_blacklisted(entry)
+            )
+        ]
+
+    def get_duration_to_dispatch(self, window):
+        """Returns the time to dispatch to entries
+        i.e. total amount of dispatchable entries divided byt the quantity of
+        entries to dispatch
+        """
+        entries_to_dispatch = self.get_entries_to_dispatch(window)
+        durations = [
+            int(duration.total_seconds())
+            for start, stop, duration, tags, entry in window.all_entries()
+            if self.is_dispatch_entry(entry)
+        ]
+        total_duration = sum(durations)
+        return total_duration / len(entries_to_dispatch)
+
+    def get_issue_description(self, entry):
+        # remove comments
+        line = entry.split('|')[0]
+        try:
+            # remove category
+            if self.line_format == 'categorized':
+                # category is optional
+                if ':' in line:
+                    line = line.split(':', 1)[1].strip()
+            issue, description = [
+                x.strip() for x in line.split(self.delimiter, 1)
+                if x.strip()
+            ]
+        except ValueError:
+            print(
+                'Entry must be in the format `{}`. '
+                'Got '.format(self.line_format_str), entry
+            )
+            return
+
+        # no matter what we find as `issue`:
+        # if we have an alias override it takes precedence
+        if issue in self.aliases:
+            issue = self.aliases[issue]
+        return issue, description
+
+    def dispatch_entries(self, window):
+        entries_to_dispatch = self.get_entries_to_dispatch(window)
+        duration_to_dispatch = self.get_duration_to_dispatch(window)
+
+        entries_to_return = []
+        for start, stop, duration, tags, entry in window.all_entries():
+            if self.skip_entry(entry):
+                continue
+
+            issue, description = self.get_issue_description(entry)
+
+            dispatched_duration = int(duration.total_seconds())
+            # Apply dispatch to dispatchable entries only
+            if entry in entries_to_dispatch:
+                dispatched_duration = (
+                        int(duration.total_seconds()) + duration_to_dispatch
+                )
+            log_entry = MultiLog(
+                None,
+                issue,
+                dispatched_duration,
+                start.date(),
+                start.time(),
+                description
+            )
+            if not self.is_dispatch_entry(entry):
+                entries_to_return.append(log_entry)
+        return entries_to_return
+
     def get_entries(self, date_window):
         window = self.timelog.window_for(date_window.start, date_window.stop)
 
-        worklogs = []
+        worklogs = self.dispatch_entries(window)
+        dispatchlogs = []
         attendances = []
+
         for start, stop, duration, tags, entry in window.all_entries():
             if self.skip_entry(entry):
                 continue
@@ -80,4 +189,4 @@ class GtimelogParser(object):
         if attendances and attendances[-1][1].date() == date.today():
             attendances[-1] = (attendances[-1][0], None)
 
-        return attendances, worklogs
+        return attendances, worklogs, dispatchlogs

--- a/wrappers/gtimelog_parser.py
+++ b/wrappers/gtimelog_parser.py
@@ -72,6 +72,7 @@ class GtimelogParser(object):
                 issue,
                 int(duration.total_seconds()),
                 start.date(),
+                start.time(),
                 description
             ))
 

--- a/wrappers/jira_client.py
+++ b/wrappers/jira_client.py
@@ -99,6 +99,7 @@ class JiraClient(object):
                         None,  # Populated later
                         entry['timeSpentSeconds'],
                         parser.parse(entry['startDate']).date(),
+                        parser.parse(entry['startTime']).time(),
                         entry['description']
                     )
                 )
@@ -113,11 +114,11 @@ class JiraClient(object):
 
     def create_worklog(self, worklog):
         values = {
-            "issueId": worklog.id,
+            "issueId": worklog.issue,
             "authorAccountId": self.account_id,
             "description": worklog.comment,
             "startDate": worklog.date.strftime('%Y-%m-%d'),
-            "startTime": "02:00:00",
+            "startTime":  worklog.time.strftime('%H:%M:%S'),
             "timeSpentSeconds": worklog.duration
         }
 

--- a/wrappers/jira_client.py
+++ b/wrappers/jira_client.py
@@ -78,6 +78,21 @@ class JiraClient(object):
         url = urljoin(self.jira_url, f'rest/api/latest/issue/{issue}')
         return self.jira_session.get(url, params={"fields": fields})
 
+    def check_issue(self, issue):
+        response = self.get_issue(issue)
+        result = {
+            'ok': True,
+            'errors': '',
+        }
+        if not response.ok:
+            # we get something like this
+            # {"errorMessages": ["Issue Does Not Exist"],"errors": {}}
+            result = {
+                'ok': False,
+                'errors': ','.join(response.json()['errorMessages'])
+            }
+        return result
+
     def get_worklogs(self, date_window):
         url = self.worklog_url
         response = self.tempo_session.get(
@@ -121,7 +136,6 @@ class JiraClient(object):
             "startTime":  worklog.time.strftime('%H:%M:%S'),
             "timeSpentSeconds": worklog.duration
         }
-
         return self.tempo_session.post(
             self.worklog_create_url,
             json=values,

--- a/wrappers/multi_log.py
+++ b/wrappers/multi_log.py
@@ -3,15 +3,16 @@ from collections import namedtuple
 
 class MultiLog:
 
-    def __init__(self, _id, issue, duration, date, comment):
+    def __init__(self, _id, issue, duration, date, time, comment):
         self.id = int(_id) if _id else None
         self.issue = issue
         self.duration = duration
         self.date = date
+        self.time = time
         self.comment = comment
 
     __slots__ = (
-        "id", "issue", "duration", "date", "comment"
+        "id", "issue", "duration", "date", "time", "comment"
     )
 
     def _asdict(self):


### PR DESCRIPTION
[BSRD-640](https://jira.camptocamp.com/browse/BSRD-640)

Due to the new way to timesheet specific tasks, here is a proposal to add two new concepts in task management.

 - internal entry line:
   - these entries refer to an internal issue reference (prefixed by `BS-, BSRD-, ABFR-, ABCH-, TBFR-, TBCH-, ...`)
 - dispatch entry line:
   - entries that will produce a quantity of time to dispatch equally along the other non internal related log entries.
   - detected with the `++` symbol in the comment or description.

See documentation for further explanation.


[BSRD-640]: https://camptocamp.atlassian.net/browse/BSRD-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ