### PR TITLE
Add feature: fix remaining estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ configuration option:
 ## Roadmap
 
 * Check if conflicting worklogs could be updated instead of deleting and recreating them
-* Update the remaining estimate on the Jira task instead of setting it to 0
 * Optimize logs aggregation
 * Better error management
 * Build a package

--- a/exporter.py
+++ b/exporter.py
@@ -6,7 +6,7 @@ import configparser
 import pathlib
 
 from builtins import input
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 from datetime import datetime, date, timedelta
 from getpass import getpass
 from os import environ as env
@@ -268,7 +268,7 @@ if __name__ == '__main__':
 
         if repair_estimate:
             # Get a unique list of all the issues impacted
-            to_repair = list(OrderedDict.fromkeys([l.issue for l in to_create] + [l.issue for l in to_delete]))
+            to_repair = set([l.issue for l in to_create] + [l.issue for l in to_delete])
             for i in to_repair:
                 try:
                     jira.repair_estimate(i)

--- a/wrappers/jira_client.py
+++ b/wrappers/jira_client.py
@@ -150,9 +150,10 @@ class JiraClient(object):
         if not response.ok:
             raise Exception(f"Cannot get issue: {issue}")
         try:
-            original_estimate_s = response.json()['fields']['timetracking']['originalEstimateSeconds']
-            original_estimate = response.json()['fields']['timetracking']['originalEstimate']
-            timespent_s = response.json()['fields']['timetracking']['timeSpentSeconds']
+            timetracking = response.json()['fields']['timetracking']
+            original_estimate_s = timetracking['originalEstimateSeconds']
+            original_estimate = timetracking['originalEstimate']
+            timespent_s = timetracking['timeSpentSeconds']
             diff_o_e_vs_t_s = original_estimate_s - timespent_s
             remaining_estimate_s = diff_o_e_vs_t_s if diff_o_e_vs_t_s >= 0 else 0
 

--- a/wrappers/jira_client.py
+++ b/wrappers/jira_client.py
@@ -148,7 +148,7 @@ class JiraClient(object):
     def repair_estimate(self, issue):
         response = self.get_issue(issue)
         if not response.ok:
-            raise Exception(f"Cannot get issue: {issue}")
+            raise Exception(f"Cannot fetch information for issue: {issue}")
         try:
             timetracking = response.json()['fields']['timetracking']
             original_estimate_s = timetracking['originalEstimateSeconds']
@@ -171,4 +171,4 @@ class JiraClient(object):
             self.session.headers.update({"Content-Type": "application/json"})
             put_response = self.session.put(url, json=payload)
         except KeyError as e:
-            raise Exception(f'impossible to edit remaining estimate in given issue: {issue}, check permissions and jira workflow. Possibly the "originalEstimate filed is not editable.')
+            raise Exception(f"repair_estimate: impossible to edit remaining estimate for {issue}. Check permissions and jira workflow. Maybe the `originalEstimate` field is not editable.")


### PR DESCRIPTION
This PR adds the feature to fix the remaining estimate of an issue. I have made the choice to write it in an idempotent way, instead of loading in memory and trying to update it within the `create_worklog` method. The problems are that not all the issues have or can have (depending on workflow or permissions) the field `originalEstimate` . 

The option to repair the estimate is `False` by default and must be explicitly set in command line.