### PR TITLE
Extend list instead of append

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -98,7 +98,7 @@ class Utils:
         ]
 
         if not (args.no_attendance or result.get('no_attendance')):
-            mandatory_fields.append([
+            mandatory_fields.extend([
                 'odoo_url',
                 'odoo_db',
                 'odoo_user'


### PR DESCRIPTION
In my install I get this error with `append` but with an `extend` it is solved

```
Traceback (most recent call last):
  File "gtimelog2odoo/./exporter.py", line 199, in <module>
    config = Utils.parse_config(args)
  File "gtimelog2odoo/./exporter.py", line 106, in parse_config
    if len(set(mandatory_fields) - set(result.keys())) > 0:
TypeError: unhashable type: 'list'
```