### PR TITLE
Bail on unordered gtimelog entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.~*
 
 # local config file
-gtimelogrc
+/gtimelogrc
 
-set_passwords
+/set_passwords
+/venv


### PR DESCRIPTION
Makes gtimelog parsing unforgiving... and correct.

This has no influence for people only using the GUI.
And a life-saver for the others!